### PR TITLE
allow resolv_conf class to be instantiated without the options parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,7 +2,7 @@ class resolv_conf(
   $searchpath,
   $nameservers,
   $domainname = $domain,
-  $options = undef,
+  $options = [],
   $use_dnsmasq = false
 ) {
   include resolv_conf::params


### PR DESCRIPTION
The present default value for class { 'resolv_conf': options => ... } is undef.
This causes the following error in resolv.conf.erb when no options parameter is set in the class definition.

```
Failed to parse template resolv_conf/resolv.conf.erb:
  Filepath: /etc/puppet/modules/resolv_conf/templates/resolv.conf.erb
  Line: 10
  Detail: undefined method `empty?' for :undef:Symbol
 at /etc/puppet/modules/resolv_conf/manifests/config.pp:13 on node ...
```

This patch fixes this by changing the default value for options to an empty
list ([]) although a more robust solution may be to refactor the ERB template.
