### PR TITLE
add support for $::operatingsystem = gentoo 

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,14 @@ class resolv_conf::params {
       $config_file = '/etc/resolv.conf'
     }
     default: {
-      fail("Unsupported platform: ${::osfamily}")
+      case $::operatingsystem {
+        gentoo: {
+          $config_file = '/etc/resolv.conf'
+        } 
+        default: {
+          fail("Unsupported platform: ${::osfamily}/${::operatingsystem}")
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This pull request also includes the patch "add $module_name to unsupported platform fail() message" but I will remove this if it's unacceptable.
