### PR TITLE
Fix variable reference deprecation warning

### DIFF
--- a/templates/resolv.conf.erb
+++ b/templates/resolv.conf.erb
@@ -1,19 +1,19 @@
 # File managed by puppet
 
-domain <%= domainname %>
-<% if !searchpath.empty? -%>
-<% if searchpath.kind_of? Array -%>
+domain <%= @domainname %>
+<% if !@searchpath.empty? -%>
+<% if @searchpath.kind_of? Array -%>
 search <%= searchpath.join(" ") %>
 <% else -%>
-search <%= searchpath %>
+search <%= @searchpath %>
 <% end -%>
 <% end -%>
-<% if use_dnsmasq == true -%>
+<% if @use_dnsmasq == true -%>
 nameserver 127.0.0.1
 <% end -%>
-<% nameservers.each do |ns| -%>
+<% @nameservers.each do |ns| -%>
 nameserver <%= ns %>
 <% end -%>
-<% if @options && !options.empty? -%>
-options <%= options.join(" ") %>
+<% if @options && !@options.empty? -%>
+options <%= @options.join(" ") %>
 <% end -%>


### PR DESCRIPTION
Fixes warnings like 'Warning: Variable access via 'domainname' is deprecated. Use '@domainname' instead.'
