### PR TITLE
access searchpath var as an instance var in erb template

### DIFF
--- a/templates/resolv.conf.erb
+++ b/templates/resolv.conf.erb
@@ -3,7 +3,7 @@
 domain <%= @domainname %>
 <% if !@searchpath.empty? -%>
 <% if @searchpath.kind_of? Array -%>
-search <%= searchpath.join(" ") %>
+search <%= @searchpath.join(" ") %>
 <% else -%>
 search <%= @searchpath %>
 <% end -%>


### PR DESCRIPTION
Resolves this warning:

```
Thu Oct 17 04:56:45 -0700 2013 Puppet (warning): Variable access via
'searchpath' is deprecated. Use '@searchpath' instead.
template[/etc/puppet/env/production/modules/resolv_conf/templates/resolv.conf.erb]:6
```
