### PR TITLE
Fix metadata to work on pe 3.3

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "saz-resolv_conf",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "saz",
   "summary": "UNKNOWN",
   "license": "Apache License, Version 2.0",
@@ -45,7 +45,7 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": "3.2.x"
+      "version_requirement": ">=3.2.0 < 3.4.0"
     },
     {
       "name": "puppet",


### PR DESCRIPTION
This will fix the metadata to allow PE 3.3 to use the module.

The spec tests for this build will fail, but those should be fixed with https://github.com/saz/puppet-resolv_conf/pull/20
