### PR TITLE
Fix failed domainname and searchpath clash

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,7 @@
 class resolv_conf(
   $nameservers,
   $domainname = undef,
-  $searchpath = [],
+  $searchpath = undef,
   $options = undef
 ) inherits resolv_conf::params {
 

--- a/templates/resolv.conf.erb
+++ b/templates/resolv.conf.erb
@@ -3,7 +3,7 @@
 <%- if @domainname_real -%>
 domain <%= @domainname %>
 <%- end -%>
-<% if !@searchpath.empty? -%>
+<% if @searchpath && !@searchpath.empty? -%>
 <% if @searchpath.kind_of? Array -%>
 search <%= @searchpath.join(" ") %>
 <% else -%>


### PR DESCRIPTION
If you have domainname set with no searchpath defined, the domain parameter would not get set in /etc/resolv.conf.

There are a couple of solutions to this problem, one of which it to use the empty() function from stdlib, but given that this class doesn't already use it, I opted for changing default searchpath parameter to undef instead of [] and then check for this in the template. 

It may be that this behaviour only occurs with future parser, but this commit should work with either parser.
