### PR TITLE
Add support for Solaris 11

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,12 +30,21 @@ class resolv_conf(
     fail("domainname and searchpath are mutually exclusive parameters")
   }
 
-  file { 'resolv.conf':
-    ensure  => file,
-    path    => $resolv_conf::params::config_file,
-    owner   => 'root',
-    group   => $resolv_conf::params::group,
-    mode    => '0644',
-    content => template('resolv_conf/resolv.conf.erb'),
+  if $osfamily == 'Solaris' and $operatingsystemmajrelease == '11' {
+    class { 'resolv_conf::solaris':
+      domainname => $domainname_real,
+      searchpath => $searchpath,
+      nameservers => $nameservers,
+      options => $options,
+    }
+  } else { 
+    file { 'resolv.conf':
+      ensure  => file,
+      path    => $resolv_conf::params::config_file,
+      owner   => 'root',
+      group   => $resolv_conf::params::group,
+      mode    => '0644',
+      content => template('resolv_conf/resolv.conf.erb'),
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,17 +27,17 @@ class resolv_conf(
   } elsif $domainname != undef and $searchpath == [] {
     $domainname_real = $domainname
   } elsif $domainname != undef and $searchpath != [] {
-    fail("domainname and searchpath are mutually exclusive parameters")
+    fail('domainname and searchpath are mutually exclusive parameters')
   }
 
-  if $osfamily == 'Solaris' and $operatingsystemmajrelease == '11' {
+  if $::osfamily == 'Solaris' and $::operatingsystemmajrelease == '11' {
     class { 'resolv_conf::solaris':
-      domainname => $domainname_real,
-      searchpath => $searchpath,
+      domainname  => $domainname_real,
+      searchpath  => $searchpath,
       nameservers => $nameservers,
-      options => $options,
+      options     => $options,
     }
-  } else { 
+  } else {
     file { 'resolv.conf':
       ensure  => file,
       path    => $resolv_conf::params::config_file,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,7 @@ class resolv_conf::params {
       $config_file = '/etc/resolv.conf'
       $group       = 'root'
     }
+    'Solaris': { }
     
     default: {
       case $::operatingsystem {

--- a/manifests/solaris.pp
+++ b/manifests/solaris.pp
@@ -5,10 +5,10 @@ class resolv_conf::solaris (
   $options,
 ) {
 
-  $nameserver_string = join(any2array($nameserver), ' ')
+  $nameservers_string = join($nameservers, ' ')
 
-  exec { "/usr/sbin/svccfg -s dns/client setprop config/nameserver = net_address: \"(${nameserver_string})\"":
-    unless => "/usr/sbin/svccfg -s dns/client listprop config/nameserver | grep \"${nameserver_string}\"",
+  exec { "/usr/sbin/svccfg -s dns/client setprop config/nameserver = net_address: \"(${nameservers_string})\"":
+    unless => "/usr/sbin/svccfg -s dns/client listprop config/nameserver | grep \"${nameservers_string}\"",
   }
     
 }

--- a/manifests/solaris.pp
+++ b/manifests/solaris.pp
@@ -1,0 +1,24 @@
+class resolv_conf::solaris (
+  $domainname,
+  $searchpath,
+  $nameservers,
+  $options,
+) {
+
+  svccfg { 'resolv-nameserver':
+    ensure => present,
+    fmri => 'svc:/network/dns/client,
+    property => 'config/nameserver',
+    type => 'array',
+    value => $nameservers,
+  }
+
+  svccfg { 'resolv-searchpath':
+    ensure => present,
+    fmri => 'svc:/network/dns/client,
+    property => 'config/search',
+    type => 'string',
+    value => $searchpath,
+  }
+
+}

--- a/manifests/solaris.pp
+++ b/manifests/solaris.pp
@@ -5,7 +5,7 @@ class resolv_conf::solaris (
   $options,
 ) {
 
-  $nameserver_string = join($nameserver, ' ')
+  $nameserver_string = join(any2array($nameserver), ' ')
 
   exec { "/usr/sbin/svccfg -s dns/client setprop config/nameserver = net_address: \"(${nameserver_string})\"":
     unless => "/usr/sbin/svccfg -s dns/client listprop config/nameserver | grep \"${nameserver_string}\"",

--- a/manifests/solaris.pp
+++ b/manifests/solaris.pp
@@ -7,14 +7,14 @@ class resolv_conf::solaris (
 
   $nameservers_string = join($nameservers, ' ')
 
-  exec { "/usr/sbin/svccfg -s dns/client setprop config/nameserver = net_address: \"(${nameservers_string})\"":
-    unless => "/usr/sbin/svccfg -s dns/client listprop config/nameserver | grep \"${nameservers_string}\"",
+  exec { "/usr/sbin/svccfg -s dns/client setprop config/nameserver = net_address: '(${nameservers_string})'":
+    unless => "/usr/sbin/svccfg -s dns/client listprop config/nameserver | grep '${nameservers_string}'",
   }
     
   $search_string = join(any2array($searchpath), ' ')
 
-  exec { "/usr/sbin/svccfg -s dns/client setprop config/search = astring: \"(${search_string})\"":
-    unless => "/usr/sbin/svccfg -s dns/client listprop config/search | grep \"${search_string}\"",
+  exec { "/usr/sbin/svccfg -s dns/client setprop config/search = astring: '(\"${search_string}\")'":
+    unless => "/usr/sbin/svccfg -s dns/client listprop config/search | grep '${search_string}'",
   }
 
 }

--- a/manifests/solaris.pp
+++ b/manifests/solaris.pp
@@ -11,4 +11,10 @@ class resolv_conf::solaris (
     unless => "/usr/sbin/svccfg -s dns/client listprop config/nameserver | grep \"${nameservers_string}\"",
   }
     
+  $search_string = join(any2array($searchpath), ' ')
+
+  exec { "/usr/sbin/svccfg -s dns/client setprop config/search = astring: \"(${search_string})\"":
+    unless => "/usr/sbin/svccfg -s dns/client listprop config/search | grep \"${search_string}\"",
+  }
+
 }

--- a/manifests/solaris.pp
+++ b/manifests/solaris.pp
@@ -7,7 +7,7 @@ class resolv_conf::solaris (
 
   svccfg { 'resolv-nameserver':
     ensure => present,
-    fmri => 'svc:/network/dns/client,
+    fmri => 'svc:/network/dns/client',
     property => 'config/nameserver',
     type => 'array',
     value => $nameservers,
@@ -15,7 +15,7 @@ class resolv_conf::solaris (
 
   svccfg { 'resolv-searchpath':
     ensure => present,
-    fmri => 'svc:/network/dns/client,
+    fmri => 'svc:/network/dns/client',
     property => 'config/search',
     type => 'string',
     value => $searchpath,

--- a/manifests/solaris.pp
+++ b/manifests/solaris.pp
@@ -7,14 +7,21 @@ class resolv_conf::solaris (
 
   $nameservers_string = join($nameservers, ' ')
 
-  exec { "/usr/sbin/svccfg -s dns/client setprop config/nameserver = net_address: '(${nameservers_string})'":
-    unless => "/usr/sbin/svccfg -s dns/client listprop config/nameserver | grep '${nameservers_string}'",
+  exec { "/usr/sbin/svccfg -s svc:/network/dns/client setprop config/nameserver = net_address: '(${nameservers_string})'":
+    unless => "/usr/sbin/svccfg -s svc:/network/dns/client listprop config/nameserver | grep '${nameservers_string}'",
+    notify => Service['svc:/network/dns/client'],
   }
     
   $search_string = join(any2array($searchpath), ' ')
 
-  exec { "/usr/sbin/svccfg -s dns/client setprop config/search = astring: '(\"${search_string}\")'":
-    unless => "/usr/sbin/svccfg -s dns/client listprop config/search | grep '${search_string}'",
+  exec { "/usr/sbin/svccfg -s svc:/network/dns/client setprop config/search = astring: '(\"${search_string}\")'":
+    unless => "/usr/sbin/svccfg -s svc:/network/dns/client listprop config/search | grep '${search_string}'",
+    notify => Service['svc:/network/dns/client'],
+  }
+
+  service { 'svc:/network/dns/client':
+    ensure => running,
+    enable => true,
   }
 
 }

--- a/manifests/solaris.pp
+++ b/manifests/solaris.pp
@@ -5,20 +5,10 @@ class resolv_conf::solaris (
   $options,
 ) {
 
-  svccfg { 'resolv-nameserver':
-    ensure => present,
-    fmri => 'svc:/network/dns/client',
-    property => 'config/nameserver',
-    type => 'array',
-    value => $nameservers,
-  }
+  $nameserver_string = join($nameserver, ' ')
 
-  svccfg { 'resolv-searchpath':
-    ensure => present,
-    fmri => 'svc:/network/dns/client',
-    property => 'config/search',
-    type => 'string',
-    value => $searchpath,
+  exec { "/usr/sbin/svccfg -s dns/client setprop config/nameserver = net_address: \"(${nameserver_string})\"":
+    unless => "/usr/sbin/svccfg -s dns/client listprop config/nameserver | grep \"${nameserver_string}\"",
   }
-
+    
 }


### PR DESCRIPTION
Had a customer that required resolv.conf support for Solaris 11. This uses svccfg since Solaris 11 does not use the config file for dns configuration.