### PR TITLE
Make it work on solaris < 10

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,7 +24,11 @@ class resolv_conf::params {
       $config_file = '/etc/resolv.conf'
       $group       = 'root'
     }
-    'Solaris': { }
+    'Solaris': {
+      # This will only be used on Solaris < 11
+      $config_file = '/etc/resolv.conf'
+      $group       = 'root'
+    }
     
     default: {
       case $::operatingsystem {


### PR DESCRIPTION
The current code deals with the new config mechanism on Solaris 11 but doesn't provide the _path_ and _group_ params for older versions of Solaris. This adds those settings and makes it work on Solaris 10 and earlier.
