### PR TITLE
Adding documentation head to avoid puppet-style warning

### DIFF
--- a/manifests/solaris.pp
+++ b/manifests/solaris.pp
@@ -1,3 +1,13 @@
+# == Class: resolv_conf::solaris
+#
+# This class handles solaris
+#
+# == Variables
+#  [*domainname*]
+#  [*searchpath*]
+#  [*nameservers*]
+#  [*options*]
+#
 class resolv_conf::solaris (
   $domainname,
   $searchpath,


### PR DESCRIPTION
Got a warning that the class documentation for resolv_conf::solars was missing. Added some class header to the file.
