### PR TITLE
Make options be one-per-line not concatenated in one

### DIFF
--- a/spec/classes/resolv_conf_spec.rb
+++ b/spec/classes/resolv_conf_spec.rb
@@ -126,7 +126,9 @@ describe 'resolv_conf' do
             end
 
             if param_hash[:options] && !param_hash[:options].empty?
-              expected_lines.push('options ' + param_hash[:options].join(' '))
+              param_hash[:options].each do |option|
+                expected_lines.push("option #{option}")
+              end
             end
             (content.split("\n") & expected_lines).should =~ expected_lines
           end
@@ -198,7 +200,9 @@ describe 'resolv_conf' do
             end
 
             if param_hash[:options] && !param_hash[:options].empty?
-              expected_lines.push('options ' + param_hash[:options].join(' '))
+              param_hash[:options].each do |option|
+                expected_lines.push("option #{option}")
+              end
             end
             (content.split("\n") & expected_lines).should =~ expected_lines
           end
@@ -271,7 +275,9 @@ describe 'resolv_conf' do
             end
 
             if param_hash[:options] && !param_hash[:options].empty?
-              expected_lines.push('options ' + param_hash[:options].join(' '))
+              param_hash[:options].each do |option|
+                expected_lines.push("option #{option}")
+              end
             end
             (content.split("\n") & expected_lines).should =~ expected_lines
           end

--- a/templates/resolv.conf.erb
+++ b/templates/resolv.conf.erb
@@ -14,5 +14,7 @@ search <%= @searchpath %>
 nameserver <%= ns %>
 <% end -%>
 <% if @options && !@options.empty? -%>
-options <%= @options.join(" ") %>
+<% @options.each do |option| -%>
+options <%= option %>
+<% end -%>
 <% end -%>


### PR DESCRIPTION
Prior to this, an array of options would end up all on one "options" line, rather than one per line.  This change replaces the behavior of making a single options line that does a .join of the options, with an iteration over the array to produce one line per option.