### PR TITLE
Puppet >= 4.9.3 is required for hiera 5 fixes #51

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Manage resolv.conf via Puppet
 If you find this module useful, send some bitcoins to 1Na3YFUmdxKxJLiuRXQYJU2kiNqA3KY2j9
 
 ### Supported Puppet versions
-* Puppet >= 4
+* Puppet >= 4.9.3
 * Last version supporting Puppet 3: v3.3.0
 
 ## Usage

--- a/metadata.json
+++ b/metadata.json
@@ -47,7 +47,7 @@
     }
   ],
   "requirements": [
-    { "name": "puppet", "version_requirement": ">=4.0.0 <6.0.0" }
+    { "name": "puppet", "version_requirement": ">=4.9.3 <6.0.0" }
   ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">=2.6.0 < 5.0.0" }


### PR DESCRIPTION
https://puppet.com/docs/puppet/4.9/release_notes.html