### PR TITLE
Update metadata to indicate Solaris compatibility

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -44,6 +44,9 @@
     },
     {
       "operatingsystem": "AIX"
+    },
+    {
+      "operatingsystem": "Solaris"
     }
   ],
   "requirements": [


### PR DESCRIPTION
This module has support for Solaris, so this commit simply adds Solaris to the module's compatibility metadata, so it will appear in the forge page.