### PR TITLE
Fix for options in Solaris 11

### DIFF
--- a/templates/resolv.conf_sol11.erb
+++ b/templates/resolv.conf_sol11.erb
@@ -16,11 +16,9 @@ search	<%= @searchpath.uniq().join(" ") %>
 search	<%= @searchpath %>
 <% end -%>
 <% end -%>
+<% if @options && !@options.empty? -%>
+options	<%= @options.join(" ") %>
+<% end -%>
 <% @nameservers.each do |ns| -%>
 nameserver	<%= ns %>
-<% end -%>
-<% if @options && !@options.empty? -%>
-<% @options.each do |option| -%>
-options	<%= option %>
-<% end -%>
 <% end -%>


### PR DESCRIPTION
- Options space separated on one line
- Put nameserver lines last to avoid corrective change