### PR TITLE
Use stdlib:: namespace prefix for puppet 4.x function

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,5 @@
 fixtures:
   symlinks:
     "resolv_conf": "#{source_dir}"
-  repositories:
-    stdlib: "http://github.com/puppetlabs/puppetlabs-stdlib.git"
+  forge_modules:
+    stdlib: "puppetlabs/stdlib"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,7 +36,7 @@ class resolv_conf (
   }
 
   if $manage_package {
-    ensure_packages([
+    stdlib::ensure_packages([
         $package,
       ], {
         'ensure' => $package_ensure,

--- a/metadata.json
+++ b/metadata.json
@@ -53,6 +53,6 @@
     { "name": "puppet", "version_requirement": ">=7.0.0 <9.0.0" }
   ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">=2.6.0 < 10.0.0" }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">=9.0.0 < 10.0.0" }
   ]
 }


### PR DESCRIPTION
[This change](https://github.com/puppetlabs/puppetlabs-stdlib/pull/1356) requires stdlib >= 9, this should ensure compatibility with Puppet 8.
