### PR TITLE
Use ensure_resource insted of stdlib::ensure_packages

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,5 @@
 fixtures:
   forge_modules:
-    stdlib: "puppetlabs/stdlib"
+    stdlib:
+      repo: "puppetlabs/stdlib"
+      ref: 4.12.0

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,11 +36,7 @@ class resolv_conf (
   }
 
   if $manage_package {
-    stdlib::ensure_packages([
-        $package,
-      ], {
-        'ensure' => $package_ensure,
-    })
+    ensure_resource('package', $package, { 'ensure' => $package_ensure })
   }
 
   if $use_resolvconf {

--- a/metadata.json
+++ b/metadata.json
@@ -53,6 +53,6 @@
     { "name": "puppet", "version_requirement": ">=7.0.0 <9.0.0" }
   ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">=9.0.0 < 10.0.0" }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">=4.12.0 < 10.0.0" }
   ]
 }


### PR DESCRIPTION
This way stdlib >= 9 is not required (#77)

If I'm not mistaken `ensure_packages` [calls under the hood `ensure_resource`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/a01ed37faaf8e77d4a5eab3cfe588e50eac386f6/lib/puppet/functions/stdlib/ensure_packages.rb#L40). So the functionality should be the same.

This might relax dependencies of this module. Sorry, I'm a bit late with the PR :disappointed: 

Instead of jumping dependency from `>=2.6.0` to `9.0.0` we might be able to use `>=4.12.0` as minimal `puppetlabs/stdlib` requirement.