### PR TITLE
Release 8.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
+## [v8.0.1](https://github.com/saz/puppet-resolv_conf/tree/v8.0.1) (2025-10-27)
+
+[Full Changelog](https://github.com/saz/puppet-resolv_conf/compare/v8.0.0...v8.0.1)
+
+**Merged pull requests:**
+
+- update README, add REFERENCE.md [\#86](https://github.com/saz/puppet-resolv_conf/pull/86) ([saz](https://github.com/saz))
+
 ## [v8.0.0](https://github.com/saz/puppet-resolv_conf/tree/v8.0.0) (2025-10-27)
 
 [Full Changelog](https://github.com/saz/puppet-resolv_conf/compare/v7.0.0...v8.0.0)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "saz-resolv_conf",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "author": "saz",
   "summary": "Manage resolv.conf via Puppet",
   "description": "Manage resolv.conf via Puppet",


### PR DESCRIPTION
Automated release-prep through https://github.com/voxpupuli/gha-puppet/ from commit 2aa63df4c7d336ee570390d023f01385bfbfa32c.
Checkout the [module release instructions](https://voxpupuli.org/docs/releasing_version/).